### PR TITLE
[EI-82]-shortcodes-fatal-error

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -342,7 +342,7 @@ function do_shortcode_content( $atts, string $content = '' ) : string {
 			$keep = false;
 		}
 	}
-var_dump($keep);
+
 	if ( ! $keep ) {
 		return '';
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -172,10 +172,9 @@ function register_shortcodes() {
 /**
  * Output the current continent
  *
- * @param array $atts The shortcode attributes.
  * @return string The continent.
  */
-function do_shortcode_continent( array $atts ) : string {
+function do_shortcode_continent() : string {
 	$continent = get_continent();
 	if ( ! empty( $continent ) ) {
 		return $continent;
@@ -187,10 +186,9 @@ function do_shortcode_continent( array $atts ) : string {
 /**
  * Output the current country
  *
- * @param array $atts The shortcode attributes.
  * @return string The country.
  */
-function do_shortcode_country( array $atts ) : string {
+function do_shortcode_country() : string {
 	$country = get_country();
 	if ( ! empty( $country ) ) {
 		return $country;
@@ -202,10 +200,9 @@ function do_shortcode_country( array $atts ) : string {
 /**
  * Output the current region
  *
- * @param array $atts The shortcode attributes.
  * @return string The region.
  */
-function do_shortcode_region( array $atts ) : string {
+function do_shortcode_region() : string {
 	$region = get_region();
 	if ( ! empty( $region ) ) {
 		return $region;
@@ -217,10 +214,9 @@ function do_shortcode_region( array $atts ) : string {
 /**
  * Output the current city
  *
- * @param array $atts The shortcode attributes.
  * @return string The city.
  */
-function do_shortcode_city( array $atts ) : string {
+function do_shortcode_city() : string {
 	$city = get_city();
 	if ( ! empty( $city ) ) {
 		return $city;
@@ -232,10 +228,9 @@ function do_shortcode_city( array $atts ) : string {
 /**
  * Output a current human-readable location
  *
- * @param array $atts The shortcode attributes.
  * @return string The postal code.
  */
-function do_shortcode_location( array $atts ) : string {
+function do_shortcode_location() : string {
 	$city = get_city();
 	$region = get_region();
 	$country = get_country();

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -279,11 +279,11 @@ function do_shortcode_location() : string {
 /**
  * Output the content filtered by the current location.
  *
- * @param array $atts The shortcode attributes.
+ * @param string|array $atts The shortcode attributes.
  * @param string $content The content that comes between the shortcode tags.
  * @return string The HTML content.
  */
-function do_shortcode_content( array $atts, string $content = '' ) : string {
+function do_shortcode_content( $atts, string $content = '' ) : string {
 	$keep = true;
 	$test_parameters = [];
 	$geos = get_all();

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -298,6 +298,11 @@ function do_shortcode_content( $atts, string $content = '' ) : string {
 		'not_city' => '',
 	], $atts );
 
+	// If we don't have any geolocation content is empty, just bail and return an empty string.
+	if ( empty( $geos ) ) {
+		return '';
+	}
+
 	foreach ( $atts as $label => $value ) {
 		// Set up initial negation parameters.
 		$negate = 0;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -287,6 +287,16 @@ function do_shortcode_content( $atts, string $content = '' ) : string {
 	$keep = true;
 	$test_parameters = [];
 	$geos = get_all();
+	$atts = shortcode_atts( [
+		'continent' => '',
+		'country' => '',
+		'region' => '',
+		'city' => '',
+		'not_continent' => '',
+		'not_country' => '',
+		'not_region' => '',
+		'not_city' => '',
+	], $atts );
 
 	foreach ( $atts as $label => $value ) {
 		// Set up initial negation parameters.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -287,16 +287,6 @@ function do_shortcode_content( $atts, string $content = '' ) : string {
 	$keep = true;
 	$test_parameters = [];
 	$geos = get_all();
-	$atts = shortcode_atts( [
-		'continent' => '',
-		'country' => '',
-		'region' => '',
-		'city' => '',
-		'not_continent' => '',
-		'not_country' => '',
-		'not_region' => '',
-		'not_city' => '',
-	], $atts );
 
 	// If we don't have any geolocation content is empty, just bail and return an empty string.
 	if ( empty( $geos ) ) {
@@ -352,7 +342,7 @@ function do_shortcode_content( $atts, string $content = '' ) : string {
 			$keep = false;
 		}
 	}
-
+var_dump($keep);
 	if ( ! $keep ) {
 		return '';
 	}


### PR DESCRIPTION
We were fataling because of some strict typing. 

The `$atts` parameter passed into the shortcode callback functions can be _either_ an array or an empty string, because WordPress ¯\_(ツ)_/¯ .

This PR removes the `$atts` parameter from functions that don't need it and removes the strict typing when it is used (`do_shortcode_content`).

This also ~adds some default attributes for `do_shortcode_content` and~ bails early in the `geoip-content` shortcode if there is no geolocation content.