### PR TITLE
[Bug] Don't require Composer autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon Geolocation Shortcodes
 
-Stable tag: 0.2.1  
+Stable tag: 0.2.2  
 Requires at least: 3.7  
 Tested up to: 5.9.1  
 Requires PHP: 7.4  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantheon-geolocation-shortcodes",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Used with the Pantheon WordPress Edge Integrations SDK, allows sites to use shortcodes to display geolocated content.",
   "scripts": {
     "bump:patch": "bump patch --commit 'Version %s.' plugin.php README.md",

--- a/plugin.php
+++ b/plugin.php
@@ -11,9 +11,9 @@
 
 namespace Pantheon\EI\WP\Shortcodes;
 
-// Check if the bootstrap function exists. If it doesn't, it means we're not using the Composer autoloader.
+// Check if the bootstrap function exists. If it doesn't, it means we're not using the Composer autoloader, so load the namespace manually.
 if ( ! function_exists( __NAMESPACE__ . '\\bootstrap' ) ) {
-	require_once __DIR__ . '/vendor/autoload.php';
+	require_once __DIR__ . '/inc/namespace.php';
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap' );

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Description: Used with the Pantheon WordPress Edge Integrations SDK, allows sites to use shortcodes to display geolocated content.
  * Author: Pantheon
  * Author URI: https://pantheon.io
- * Version: 0.2.1
+ * Version: 0.2.2
  *
  * @package Pantheon/EdgeIntegrations
  */


### PR DESCRIPTION
We are requiring the Composer autoloader in order to autoload the `inc/namespace.php` but we don't really need it for anything else.

This PR removes that require and swaps it with a require to the `namespace.php` file directly.